### PR TITLE
Fixed lifetimes conflicting requirements.

### DIFF
--- a/src/liboak/back/code_gen.rs
+++ b/src/liboak/back/code_gen.rs
@@ -26,7 +26,7 @@ use monad::partial::Partial;
 
 use std::iter::*;
 
-pub fn generate_rust_code<'cx>(cx: &'cx ExtCtxt, grammar: Grammar)
+pub fn generate_rust_code<'cx>(cx: &'cx ExtCtxt<'cx>, grammar: Grammar)
   -> Partial<Box<rust::MacResult + 'cx>>
 {
   Partial::Value(CodeGenerator::compile(cx, grammar))
@@ -64,7 +64,7 @@ struct CodeGenerator<'cx>
 
 impl<'cx> CodeGenerator<'cx>
 {
-  fn compile(cx: &'cx ExtCtxt, grammar: Grammar) -> Box<rust::MacResult + 'cx> {
+  fn compile(cx: &'cx ExtCtxt<'cx>, grammar: Grammar) -> Box<rust::MacResult + 'cx> {
     let mut compiler = CodeGenerator {
       cx: cx,
       function_gen: FunctionGenerator::new(cx),

--- a/src/liboak/back/code_printer.rs
+++ b/src/liboak/back/code_printer.rs
@@ -54,7 +54,7 @@ fn print_visible_fn(s: &mut State, item: &RItem) -> io::Result<()> {
     if let &rust::ItemKind::Fn(ref decl, unsafety, constness, abi, ref generics, _) = &item.node {
       try!(s.hardbreak_if_not_bol());
       try!(s.head(""));
-      try!(s.print_fn(decl, unsafety, constness, abi, Some(item.ident), generics, None, &item.vis));
+      try!(s.print_fn(decl, unsafety, constness, abi, Some(item.ident), generics, &item.vis));
       try!(s.end()); // end head-ibox
       try!(rust::pp::word(&mut s.s, ";"));
       try!(s.end()); // end the outer fn box

--- a/src/liboak/back/function.rs
+++ b/src/liboak/back/function.rs
@@ -25,7 +25,7 @@ pub struct FunctionGenerator<'cx>
 
 impl<'cx> FunctionGenerator<'cx>
 {
-  pub fn new(cx: &'cx ExtCtxt) -> FunctionGenerator<'cx> {
+  pub fn new(cx: &'cx ExtCtxt<'cx>) -> FunctionGenerator<'cx> {
     FunctionGenerator {
       cx: cx,
       name_factory: NameFactory::new(cx),

--- a/src/liboak/back/mod.rs
+++ b/src/liboak/back/mod.rs
@@ -32,7 +32,7 @@ use back::type_gen::*;
 use rust;
 use rust::ExtCtxt;
 
-pub fn compile<'cx>(cx: &'cx ExtCtxt, tgrammar: TGrammar) -> Partial<Box<rust::MacResult + 'cx>> {
+pub fn compile<'cx>(cx: &'cx ExtCtxt<'cx>, tgrammar: TGrammar) -> Partial<Box<rust::MacResult + 'cx>> {
   let grammar = generate_rust_types(cx, tgrammar);
   sum_type_analysis(cx, grammar)
     .and_then(|grammar| generate_rust_code(cx, grammar))

--- a/src/liboak/back/naming.rs
+++ b/src/liboak/back/naming.rs
@@ -29,7 +29,7 @@ pub struct NameFactory<'cx>
 
 impl<'cx> NameFactory<'cx>
 {
-  pub fn new(cx: &'cx ExtCtxt) -> NameFactory<'cx> {
+  pub fn new(cx: &'cx ExtCtxt<'cx>) -> NameFactory<'cx> {
     NameFactory {
       cx: cx,
       unique_id: 0

--- a/src/liboak/back/sum_type.rs
+++ b/src/liboak/back/sum_type.rs
@@ -19,7 +19,7 @@ use monad::partial::Partial;
 use rust;
 
 /// Precondition: Expects that the recursive analysis has been done.
-pub fn sum_type_analysis(cx: &ExtCtxt, grammar: Grammar)
+pub fn sum_type_analysis<'a>(cx: &'a ExtCtxt<'a>, grammar: Grammar)
   -> Partial<Grammar>
 {
   if SumType::analyse(cx, &grammar.rules) {
@@ -39,13 +39,13 @@ pub struct SumType<'a>
 
 impl<'a> SumType<'a>
 {
-  fn analyse(cx: &'a ExtCtxt, rules: &'a HashMap<Ident, Rule>) -> bool {
+  fn analyse(cx: &'a ExtCtxt<'a>, rules: &'a HashMap<Ident, Rule>) -> bool {
     let mut sum_type = SumType::new(cx, rules);
     sum_type.visit_rules();
     !sum_type.bad_type_detected
   }
 
-  fn new(cx: &'a ExtCtxt, rules: &'a HashMap<Ident, Rule>) -> SumType<'a> {
+  fn new(cx: &'a ExtCtxt<'a>, rules: &'a HashMap<Ident, Rule>) -> SumType<'a> {
     SumType {
       cx: cx,
       rules: rules,

--- a/src/liboak/back/type_gen.rs
+++ b/src/liboak/back/type_gen.rs
@@ -30,7 +30,7 @@ use middle::typing::ast::EvaluationContext;
 use back::ast::*;
 use back::ast::Expression_::*;
 
-pub fn generate_rust_types(cx: &ExtCtxt, tgrammar: TGrammar) -> Grammar {
+pub fn generate_rust_types<'a>(cx: &'a ExtCtxt<'a>, tgrammar: TGrammar) -> Grammar {
   let mut grammar = Grammar {
     name: tgrammar.name,
     rules: HashMap::with_capacity(tgrammar.rules.len()),

--- a/src/liboak/lib.rs
+++ b/src/liboak/lib.rs
@@ -42,7 +42,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
     rust::SyntaxExtension::IdentTT(Box::new(expand), None, true));
 }
 
-fn expand<'cx>(cx: &'cx mut rust::ExtCtxt, _sp: rust::Span, grammar_name: rust::Ident,
+fn expand<'cx>(cx: &'cx mut rust::ExtCtxt<'cx>, _sp: rust::Span, grammar_name: rust::Ident,
   tts: Vec<rust::TokenTree>) -> Box<rust::MacResult + 'cx>
 {
   parse(cx, grammar_name, tts)
@@ -66,7 +66,7 @@ fn unwrap_parser_ast<'a>(cx: &rust::ExtCtxt, ast: rust::PResult<'a, FGrammar>) -
   }
 }
 
-fn parse<'cx>(cx: &'cx mut rust::ExtCtxt, grammar_name: rust::Ident,
+fn parse<'cx>(cx: &'cx mut rust::ExtCtxt<'cx>, grammar_name: rust::Ident,
   tts: Vec<rust::TokenTree>) -> Box<rust::MacResult + 'cx>
 {
   let mut parser = parser::Parser::new(cx.parse_sess(), cx.cfg(), tts, grammar_name);

--- a/src/liboak/middle/analysis/mod.rs
+++ b/src/liboak/middle/analysis/mod.rs
@@ -25,7 +25,7 @@ mod undeclared_action;
 mod attribute;
 pub mod ast;
 
-pub fn analyse(cx: &ExtCtxt, fgrammar: FGrammar) -> Partial<Grammar> {
+pub fn analyse<'a>(cx: &'a ExtCtxt<'a>, fgrammar: FGrammar) -> Partial<Grammar> {
   Grammar::new(&fgrammar)
     .and_then(|grammar| rule_duplicate(cx, grammar, fgrammar.rules.clone()))
     .and_then(|grammar| rust_functions_duplicate(cx, grammar, fgrammar.rust_items.clone()))

--- a/src/liboak/middle/analysis/undeclared_action.rs
+++ b/src/liboak/middle/analysis/undeclared_action.rs
@@ -31,7 +31,7 @@ impl<'a> UndeclaredAction<'a>
     }
   }
 
-  fn has_undeclared(cx: &'a ExtCtxt<'a>, grammar: &Grammar) -> bool {
+  fn has_undeclared(cx: &'a ExtCtxt<'a>, grammar: &'a Grammar) -> bool {
     let mut analyser = UndeclaredAction {
       cx: cx,
       grammar: grammar,

--- a/src/liboak/middle/analysis/undeclared_rule.rs
+++ b/src/liboak/middle/analysis/undeclared_rule.rs
@@ -34,7 +34,7 @@ impl<'a> UndeclaredRule<'a>
     }
   }
 
-  fn has_undeclared(cx: &'a ExtCtxt<'a>, grammar: &Grammar) -> bool {
+  fn has_undeclared(cx: &'a ExtCtxt<'a>, grammar: &'a Grammar) -> bool {
     let mut analyser = UndeclaredRule {
       cx: cx,
       rules: &grammar.rules,

--- a/src/liboak/middle/mod.rs
+++ b/src/liboak/middle/mod.rs
@@ -24,7 +24,7 @@ pub use front::ast::Grammar as FGrammar;
 pub mod analysis;
 pub mod typing;
 
-pub fn analyse(cx: &ExtCtxt, fgrammar: FGrammar) -> Partial<Grammar> {
+pub fn analyse<'a>(cx: &'a ExtCtxt<'a>, fgrammar: FGrammar) -> Partial<Grammar> {
   if !at_least_one_rule_declared(cx, &fgrammar) {
     return Partial::Nothing
   }

--- a/src/liboak/middle/typing/mod.rs
+++ b/src/liboak/middle/typing/mod.rs
@@ -29,7 +29,7 @@ mod top_down_unit;
 mod recursive_type;
 // mod printer;
 
-pub fn type_inference(cx: &ExtCtxt, agrammar: AGrammar) -> Partial<Grammar> {
+pub fn type_inference<'a>(cx: &'a ExtCtxt<'a>, agrammar: AGrammar) -> Partial<Grammar> {
   let mut grammar = Grammar {
     name: agrammar.name,
     rules: HashMap::with_capacity(agrammar.rules.len()),

--- a/src/liboak/middle/typing/recursive_type.rs
+++ b/src/liboak/middle/typing/recursive_type.rs
@@ -17,7 +17,7 @@
 use middle::typing::ast::*;
 use monad::partial::Partial;
 
-pub fn recursive_type_analysis(cx: &ExtCtxt, grammar: Grammar)
+pub fn recursive_type_analysis<'a>(cx: &'a ExtCtxt<'a>, grammar: Grammar)
   -> Partial<Grammar>
 {
   if RecursiveType::analyse(cx, &grammar.rules) {
@@ -41,13 +41,13 @@ pub struct RecursiveType<'a>
 
 impl<'a> RecursiveType<'a>
 {
-  fn analyse(cx: &'a ExtCtxt, rules: &'a HashMap<Ident, Rule>) -> bool {
+  fn analyse(cx: &'a ExtCtxt<'a>, rules: &'a HashMap<Ident, Rule>) -> bool {
     let mut inlining_loop = RecursiveType::new(cx, rules);
     inlining_loop.visit_rules();
     !inlining_loop.cycle_detected
   }
 
-  fn new(cx: &'a ExtCtxt, rules: &'a HashMap<Ident, Rule>) -> RecursiveType<'a> {
+  fn new(cx: &'a ExtCtxt<'a>, rules: &'a HashMap<Ident, Rule>) -> RecursiveType<'a> {
     let mut visited = HashMap::with_capacity(rules.len());
     for id in rules.keys() {
       visited.insert(id.clone(), false);


### PR DESCRIPTION
Hi @ptal !

I was trying to update Oak to build on latest master. I've fixed pretty much all errrors but I can't tackle this one:

```sh
~/C/r/oak ❯❯❯ cargo build                                                                                                      V goyox86-fix-latest-nightly ◼
   Compiling oak v0.3.16 (file:///Users/goyox86/Code/rust/oak)
src/liboak/lib.rs:42:36: 42:52 error: type mismatch resolving `for<'cx, 'r> <fn(&'cx mut syntax::ext::base::ExtCtxt<'cx>, syntax::codemap::Span, syntax::ast::
Ident, std::vec::Vec<syntax::ast::TokenTree>) -> Box<syntax::ext::base::MacResult + 'cx> {expand} as std::ops::FnOnce<(&'cx mut syntax::ext::base::ExtCtxt<'r>
, syntax::codemap::Span, syntax::ast::Ident, std::vec::Vec<syntax::ast::TokenTree>)>>::Output == Box<syntax::ext::base::MacResult + 'cx>`:
 expected bound lifetime parameter ,
    found concrete lifetime [E0271]
src/liboak/lib.rs:42     rust::SyntaxExtension::IdentTT(Box::new(expand), None, true));
                                                        ^~~~~~~~~~~~~~~~
src/liboak/lib.rs:42:36: 42:52 help: run `rustc --explain E0271` to see a detailed explanation
src/liboak/lib.rs:42:36: 42:52 note: required because of the requirements on the impl of `syntax::ext::base::IdentMacroExpander` for `fn(&'cx mut syntax::ext:
:base::ExtCtxt<'cx>, syntax::codemap::Span, syntax::ast::Ident, std::vec::Vec<syntax::ast::TokenTree>) -> Box<syntax::ext::base::MacResult + 'cx> {expand}`
src/liboak/lib.rs:42:36: 42:52 note: required for the cast to the object type `syntax::ext::base::IdentMacroExpander + 'static`
src/liboak/lib.rs:42:36: 42:52 error: type mismatch: the type `fn(&'cx mut syntax::ext::base::ExtCtxt<'cx>, syntax::codemap::Span, syntax::ast::Ident, std::ve
c::Vec<syntax::ast::TokenTree>) -> Box<syntax::ext::base::MacResult + 'cx> {expand}` implements the trait `for<'cx> std::ops::Fn<(&'cx mut syntax::ext::base::
ExtCtxt<'cx>, syntax::codemap::Span, syntax::ast::Ident, std::vec::Vec<syntax::ast::TokenTree>)>`, but the trait `for<'cx, 'r> std::ops::Fn<(&'cx mut syntax::
ext::base::ExtCtxt<'r>, syntax::codemap::Span, syntax::ast::Ident, std::vec::Vec<syntax::ast::TokenTree>)>` is required (expected concrete lifetime, found bou
nd lifetime parameter ) [E0281]
src/liboak/lib.rs:42     rust::SyntaxExtension::IdentTT(Box::new(expand), None, true));
                                                        ^~~~~~~~~~~~~~~~
src/liboak/lib.rs:42:36: 42:52 help: run `rustc --explain E0281` to see a detailed explanation
src/liboak/lib.rs:42:36: 42:52 note: required because of the requirements on the impl of `syntax::ext::base::IdentMacroExpander` for `fn(&'cx mut syntax::ext:
:base::ExtCtxt<'cx>, syntax::codemap::Span, syntax::ast::Ident, std::vec::Vec<syntax::ast::TokenTree>) -> Box<syntax::ext::base::MacResult + 'cx> {expand}`
src/liboak/lib.rs:42:36: 42:52 note: required for the cast to the object type `syntax::ext::base::IdentMacroExpander + 'static`
error: aborting due to 2 previous errors
error: Could not compile `oak`.

To learn more, run the command again with --verbose.
~/C/r/oak ❯❯❯  
```

Any advice so we can merge this fix 😄 ?