### PR TITLE
[FIX] Fixing AST to make it compile on 1.16.0-nightly.

### DIFF
--- a/src/liboak/ast.rs
+++ b/src/liboak/ast.rs
@@ -139,7 +139,7 @@ impl<'a, 'b, ExprInfo> Grammar<'a, 'b, ExprInfo>
 
     let stream_ty = quote_ty!(self.cx, Stream);
     if let TyKind::Path(qself, mut path) = stream_ty.node.clone() {
-      path.segments.last_mut().unwrap().parameters = generics_params;
+      path.segments.last_mut().unwrap().parameters = Some(P(generics_params));
       let ty_path = TyKind::Path(qself, path);
       let ty = Ty {
         id: stream_ty.id,


### PR DESCRIPTION
Hi @ptal!

While I was compiling https://github.com/goyox86/bailey I found this:

```sh
goyox86@Bailey:~/Code/rust/oak|goyox86/1.16.0-nightly⚡ 
⇒  cargo build
    Updating registry `https://github.com/rust-lang/crates.io-index`
   Compiling partial v0.1.1
   Compiling oak v0.4.6 (file:///home/goyox86/Code/rust/oak)
error[E0308]: mismatched types
   --> src/liboak/ast.rs:142:54
    |
142 |       path.segments.last_mut().unwrap().parameters = generics_params;
    |                                                      ^^^^^^^^^^^^^^^ expected enum `std::option::Option`, found enum `syntax::ast::PathParameters`
    |
    = note: expected type `std::option::Option<syntax::ptr::P<syntax::ast::PathParameters>>`
    = note:    found type `syntax::ast::PathParameters`

error: aborting due to previous error

error: Could not compile `oak`.

To learn more, run the command again with --verbose.
```

This change fixes that!
Regards