### PR TITLE
[rustc][nightly] Update to the latest nightly rustc 1.18.0-nightly (252d3da8a 2017-04-22)

### DIFF
--- a/src/liboak/front/ast.rs
+++ b/src/liboak/front/ast.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use rust::{Spanned, BytePos, mk_sp};
+pub use rust::{Spanned, BytePos, NO_EXPANSION};
 pub use ast::*;
 
 pub struct FGrammar
@@ -69,7 +69,7 @@ impl FExpressionInfo
 {
   fn spanned(lo: BytePos, hi: BytePos) -> FExpressionInfo {
     FExpressionInfo {
-      span: mk_sp(lo, hi)
+      span: Span { lo: lo, hi: hi, ctxt: NO_EXPANSION}
     }
   }
 }

--- a/src/liboak/front/parser.rs
+++ b/src/liboak/front/parser.rs
@@ -189,7 +189,7 @@ impl<'a> Parser<'a>
     let hi = self.rp.prev_span.hi;
     if seq.len() == 0 {
       self.rp.span_err(
-        mk_sp(lo, hi),
+        Span { lo: lo, hi: hi, ctxt: NO_EXPANSION },
         format!("In rule {}: must define at least one expression.",
           rule_name).as_str())
     }

--- a/src/liboak/middle/analysis/attribute.rs
+++ b/src/liboak/middle/analysis/attribute.rs
@@ -25,8 +25,9 @@ pub fn decorate_with_attributes<'a, 'b>(mut grammar: AGrammar<'a, 'b>,
 
 fn merge_grammar_attributes<'a, 'b>(grammar: &mut AGrammar<'a, 'b>, attrs: Vec<Attribute>) {
   for attr in attrs {
-    let meta_item = attr.value;
-    merge_grammar_attr(grammar, meta_item);
+    attr.meta().map(|meta_item| {
+        merge_grammar_attr(grammar, meta_item);
+    });
   }
 }
 

--- a/src/liboak/rust.rs
+++ b/src/liboak/rust.rs
@@ -18,7 +18,7 @@ pub use syntax::ast::*;
 pub use syntax::print::pprust::*;
 pub use syntax::print::pp;
 pub use syntax::util::small_vector::SmallVector;
-pub use syntax::codemap::{DUMMY_SP, Span, MultiSpan, Spanned, spanned, mk_sp, respan, BytePos};
+pub use syntax::codemap::{DUMMY_SP, NO_EXPANSION, Span, MultiSpan, Spanned, respan, BytePos};
 pub use syntax::errors::*;
 pub use syntax::ext::base::{ExtCtxt,MacResult,MacEager,DummyResult};
 pub use syntax::ext::quote::rt::ToTokens;


### PR DESCRIPTION
Changes are based on how mk_sp was replaced in libsyntax. I'm not as sure about the meta_item change, so I took the safest option.