### PR TITLE
Update to use rust nightly-2017-04-26

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [travis-image]: https://travis-ci.org/ptal/oak.png
 [travis]: https://travis-ci.org/ptal/oak
 
-Compiled on the nightly channel of Rust. Use [rustup](http://www.rustup.rs) for managing compiler channels. You can download and set up the exact same version of the compiler used with `rustup override add nightly-2017-01-24`.
+Compiled on the nightly channel of Rust. Use [rustup](http://www.rustup.rs) for managing compiler channels. You can download and set up the exact same version of the compiler used with `rustup override add nightly-2017-04-26`.
 
 Please consult the [Oak manual](http://hyc.io/oak).
 

--- a/src/liboak/front/ast.rs
+++ b/src/liboak/front/ast.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use rust::{Spanned, BytePos, mk_sp};
+pub use rust::{Spanned, BytePos, Span, NO_EXPANSION};
 pub use ast::*;
 
 pub struct FGrammar
@@ -69,7 +69,11 @@ impl FExpressionInfo
 {
   fn spanned(lo: BytePos, hi: BytePos) -> FExpressionInfo {
     FExpressionInfo {
-      span: mk_sp(lo, hi)
+      span: Span{
+          lo: lo,
+          hi: hi,
+          ctxt: NO_EXPANSION
+      }
     }
   }
 }

--- a/src/liboak/front/parser.rs
+++ b/src/liboak/front/parser.rs
@@ -189,7 +189,7 @@ impl<'a> Parser<'a>
     let hi = self.rp.prev_span.hi;
     if seq.len() == 0 {
       self.rp.span_err(
-        mk_sp(lo, hi),
+        Span{ lo: lo, hi: hi, ctxt: NO_EXPANSION },
         format!("In rule {}: must define at least one expression.",
           rule_name).as_str())
     }

--- a/src/liboak/middle/analysis/attribute.rs
+++ b/src/liboak/middle/analysis/attribute.rs
@@ -14,8 +14,6 @@
 
 use middle::analysis::ast::*;
 
-use rust::{MetaItemKind, MetaItem};
-
 pub fn decorate_with_attributes<'a, 'b>(mut grammar: AGrammar<'a, 'b>,
   attributes: Vec<Attribute>) -> Partial<AGrammar<'a, 'b>>
 {
@@ -25,31 +23,22 @@ pub fn decorate_with_attributes<'a, 'b>(mut grammar: AGrammar<'a, 'b>,
 
 fn merge_grammar_attributes<'a, 'b>(grammar: &mut AGrammar<'a, 'b>, attrs: Vec<Attribute>) {
   for attr in attrs {
-    let meta_item = attr.value;
-    merge_grammar_attr(grammar, meta_item);
+    merge_grammar_attr(grammar, attr);
   }
 }
 
-fn merge_grammar_attr<'a, 'b>(grammar: &mut AGrammar<'a, 'b>, meta_item: MetaItem) {
-  match &meta_item.node {
-    &MetaItemKind::Word if meta_item.name == "debug_api" => {
-      grammar.merge_print_code(PrintLevel::Debug);
-    },
-    &MetaItemKind::Word if meta_item.name == "show_api" => {
-      grammar.merge_print_code(PrintLevel::Show);
-    },
-    &MetaItemKind::Word if meta_item.name == "debug_typing" => {
-      grammar.merge_print_typing(PrintLevel::Debug);
-    },
-    &MetaItemKind::Word if meta_item.name == "show_typing" => {
-      grammar.merge_print_typing(PrintLevel::Show);
-    },
-      &MetaItemKind::Word
-    | &MetaItemKind::List(_)
-    | &MetaItemKind::NameValue(_) => {
-      grammar.warn(format!(
-        "Unknown attribute `{}`: it will be ignored.",
-        meta_item.name));
+fn merge_grammar_attr<'a, 'b>(grammar: &mut AGrammar<'a, 'b>, attr: Attribute) {
+    if attr.tokens.is_empty() {
+        if attr.path == "debug_api" {
+            grammar.merge_print_code(PrintLevel::Debug);
+        } else if attr.path == "show_api" {
+            grammar.merge_print_code(PrintLevel::Show);
+        } else if attr.path == "debug_typing" {
+            grammar.merge_print_typing(PrintLevel::Debug);
+        } else if attr.path == "show_typing" {
+            grammar.merge_print_typing(PrintLevel::Show);
+        } else {
+            grammar.warn(format!("Unknown attribute `{}`: it will be ignored.", attr.path));
+        }
     }
-  }
 }

--- a/src/liboak/rust.rs
+++ b/src/liboak/rust.rs
@@ -18,7 +18,7 @@ pub use syntax::ast::*;
 pub use syntax::print::pprust::*;
 pub use syntax::print::pp;
 pub use syntax::util::small_vector::SmallVector;
-pub use syntax::codemap::{DUMMY_SP, Span, MultiSpan, Spanned, spanned, mk_sp, respan, BytePos};
+pub use syntax::codemap::{DUMMY_SP, Span, MultiSpan, Spanned, respan, BytePos, NO_EXPANSION};
 pub use syntax::errors::*;
 pub use syntax::ext::base::{ExtCtxt,MacResult,MacEager,DummyResult};
 pub use syntax::ext::quote::rt::ToTokens;


### PR DESCRIPTION
It's my first time in the internals of Rust, so I may have made a mistake here, but the code compiles and the tests all pass. The only thing I'm really unsure about is whether I'm using the correct constant for the `ctxt` member of the `syntax::codemap::Span` struct, but `NO_EXPANSION` probably seems the safest for now.