### PR TITLE
Remove unsafe out-of-bounds read in str_stream

### DIFF
--- a/runtime/src/str_stream.rs
+++ b/runtime/src/str_stream.rs
@@ -81,10 +81,6 @@ impl<'a> StrStream<'a>
   pub fn current_char(&self) -> Option<char> {
     self.raw_data[self.bytes_offset..].chars().next()
   }
-
-  pub fn slice(&self, end: StrStream<'a>) -> Option<&'a str> {
-    self.raw_data.get(self.bytes_offset..end.bytes_offset)
-  }
 }
 
 impl<'a> Iterator for StrStream<'a>

--- a/runtime/src/str_stream.rs
+++ b/runtime/src/str_stream.rs
@@ -82,10 +82,8 @@ impl<'a> StrStream<'a>
     self.raw_data[self.bytes_offset..].chars().next()
   }
 
-  pub fn slice(&self, end: StrStream<'a>) -> &'a str {
-    unsafe {
-      self.raw_data.get_unchecked(self.bytes_offset..end.bytes_offset)
-    }
+  pub fn slice(&self, end: StrStream<'a>) -> Option<&'a str> {
+    self.raw_data.get(self.bytes_offset..end.bytes_offset)
   }
 }
 


### PR DESCRIPTION
The function is not unsafe, nor does it check the unsafe preconditions.

We can either remove the function, make it unsafe, or add the check to make it safe. I chose the latter option